### PR TITLE
Add 'enforce-admins' for branch protection.

### DIFF
--- a/github/Repository.py
+++ b/github/Repository.py
@@ -2408,7 +2408,10 @@ class Repository(github.GithubObject.CompletableGithubObject):
             headers={'Accept': 'application/vnd.github.loki-preview+json'}
         )
 
-    def set_branch_protection(self, branch, require_review_all=False, require_review=None, restrictions=None, **required_status_checks):
+    def set_branch_protection(
+            self, branch, require_review_all=False,
+            require_review=None, restrictions=None, enforce_admins=None,
+            **required_status_checks):
         """
         :calls: `PUT /repos/:owner/:repo/branches/:branch/protection <https://developer.github.com/v3/repos/branches/#update-branch-protection>`_
         :param branch: string
@@ -2416,6 +2419,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         :param require_review: boolean
         :param restrictions: dict with lists as values and keys 'users' and 'teams'
         :param include_admins: boolean defaults to False
+        :param enforce_admins: set to True to enforce required status checks for repository administrators.
         :param strict: boolean defaults to False
         :param contexts: list defaults to empty lists
         """
@@ -2432,7 +2436,8 @@ class Repository(github.GithubObject.CompletableGithubObject):
             input={
                 'required_status_checks': required_status_checks,
                 'required_pull_request_reviews': require_review,
-                'restrictions' : restrictions
+                'restrictions' : restrictions,
+                'enforce_admins': enforce_admins
             },
             headers={'Accept': 'application/vnd.github.loki-preview+json'}
         )


### PR DESCRIPTION
Add 'enforce-admins', without which Github API does not allow us to set branch protection.
